### PR TITLE
CI: rename precommit job to test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 
 jobs:
-  precommit:
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Current job name gives the impression that all CI does is run pre-commit as seen in https://github.com/related-sciences/articat/runs/6028068144?check_suite_focus=true

> ![image](https://user-images.githubusercontent.com/1117703/163441649-6ce99c60-a4d6-4325-ab55-bb2267f6107d.png)

But it runs pre-commit + pytest
