### PR TITLE
Handle `None` as an explicit version value

### DIFF
--- a/articat/catalog.py
+++ b/articat/catalog.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable, Mapping
 from datetime import date
 from typing import Any, TypeVar, overload
 
-from articat.artifact import ID, Artifact, Metadata, Partition, Version
+from articat.artifact import ID, Artifact, Metadata, Partition, Version, not_supplied
 from articat.config import ArticatConfig, ConfigMixin
 
 logger = logging.getLogger(__name__)
@@ -57,7 +57,7 @@ class Catalog(ConfigMixin):
         id: ID,
         *,
         model: type[T],
-        version: Version | None = None,
+        version: Version | None = not_supplied,
         partition: Partition | None = None,
         dev: bool = False,
     ) -> T:
@@ -69,7 +69,7 @@ class Catalog(ConfigMixin):
         cls,
         id: ID,
         *,
-        version: Version | None = None,
+        version: Version | None = not_supplied,
         partition: Partition | None = None,
         model: type[Artifact] = Artifact,
         dev: bool = False,
@@ -94,7 +94,7 @@ class Catalog(ConfigMixin):
         :param model: optional model class (e.g. FSArtifact)
         :type dev: whether to use dev mode (default False)
         """
-        if not partition and not version:
+        if not partition and version is not_supplied:
             a = cls.latest_partition(id, model=model, dev=dev)
             assert isinstance(a, Artifact)
             logger.warning(
@@ -159,7 +159,7 @@ class Catalog(ConfigMixin):
         *,
         partition_dt_start: Partition | None = None,
         partition_dt_end: Partition | None = None,
-        version: Version | None = None,
+        version: Version | None = not_supplied,
         metadata: Metadata | None = None,
         limit: int | None = None,
         dev: bool = False,
@@ -175,7 +175,7 @@ class Catalog(ConfigMixin):
         model: type[T],
         partition_dt_start: Partition | None = None,
         partition_dt_end: Partition | None = None,
-        version: Version | None = None,
+        version: Version | None = not_supplied,
         metadata: Metadata | None = None,
         limit: int | None = None,
         dev: bool = False,
@@ -190,7 +190,7 @@ class Catalog(ConfigMixin):
         *,
         partition_dt_start: Partition | None = None,
         partition_dt_end: Partition | None = None,
-        version: Version | None = None,
+        version: Version | None = not_supplied,
         metadata: Metadata | None = None,
         limit: int | None = None,
         model: type[Artifact] = Artifact,
@@ -246,7 +246,7 @@ class Catalog(ConfigMixin):
         id: ID | None = None,
         partition_dt_start: Partition | None = None,
         partition_dt_end: Partition | None = None,
-        version: Version | None = None,
+        version: Version | None = not_supplied,
         metadata: Metadata | None = None,
         limit: int | None = None,
         dev: bool = False,
@@ -290,7 +290,7 @@ class Catalog(ConfigMixin):
 
         exclude = None if include_arbitrary else {"metadata": {"arbitrary": ...}}
         catalog_dicts = [
-            i.dict(exclude=exclude)  # type: ignore[arg-type]
+            i.dict(exclude=exclude)
             for i in cls.lookup(dev=dev, limit=limit, model=Artifact)
         ]
         return pd.json_normalize(catalog_dicts, sep="_")

--- a/articat/catalog_datastore.py
+++ b/articat/catalog_datastore.py
@@ -8,7 +8,7 @@ from typing import Any, TypeVar
 from google.cloud import datastore
 from google.cloud.datastore import Client, Entity, Key
 
-from articat.artifact import ID, Artifact, Metadata, Partition, Version
+from articat.artifact import ID, Artifact, Metadata, Partition, Version, not_supplied
 from articat.catalog import Catalog
 from articat.utils.datetime_utils import convert_to_datetime
 
@@ -39,7 +39,7 @@ class CatalogDatastore(Catalog):
         id: ID | None = None,
         partition_dt_start: Partition | None = None,
         partition_dt_end: Partition | None = None,
-        version: Version | None = None,
+        version: Version | None = not_supplied,
         metadata: Metadata | None = None,
         limit: int | None = None,
         dev: bool = False,
@@ -82,7 +82,7 @@ class CatalogDatastore(Catalog):
             query = client.query(kind="Partition", ancestor=client.key("Artifact", id))
         else:
             query = client.query(kind="Partition")
-        if version is None and (
+        if version in {None, not_supplied} and (
             partition_dt_start is not None or partition_dt_end is not None
         ):
             if (
@@ -103,7 +103,8 @@ class CatalogDatastore(Catalog):
                         "partition", "<", convert_to_datetime(partition_dt_end)
                     )
                 query.order = ["-partition"]
-        if version:
+        if version is not not_supplied:
+            # NOTE: version may be None here, and that's fine
             query.add_filter("version", "=", version)
         if metadata is not None:
             if metadata.schema_fields:

--- a/articat/catalog_local.py
+++ b/articat/catalog_local.py
@@ -7,7 +7,7 @@ from hashlib import md5
 from pathlib import Path
 from typing import Any
 
-from articat.artifact import ID, Artifact, Metadata, Partition, Version
+from articat.artifact import ID, Artifact, Metadata, Partition, Version, not_supplied
 from articat.catalog import Catalog
 from articat.utils.datetime_utils import convert_to_datetime
 
@@ -32,7 +32,8 @@ class CatalogLocal(Catalog):
     def _compute_key(cls, artifact: Artifact) -> str:
         h = md5()
         h.update(artifact.id.encode())
-        if artifact.version:
+        if artifact.version not in {None, not_supplied}:
+            assert isinstance(artifact.version, str)
             h.update(artifact.version.encode())
         if artifact.partition:
             assert isinstance(artifact.partition, datetime)
@@ -45,7 +46,7 @@ class CatalogLocal(Catalog):
         id: ID | None = None,
         partition_dt_start: Partition | None = None,
         partition_dt_end: Partition | None = None,
-        version: Version | None = None,
+        version: Version | None = not_supplied,
         metadata: Metadata | None = None,
         limit: int | None = None,
         dev: bool = False,
@@ -59,7 +60,7 @@ class CatalogLocal(Catalog):
                 if id is not None:
                     if a.id != id:
                         continue
-                if version is not None:
+                if version is not not_supplied:
                     if a.version != version:
                         continue
                     elif a.version == version:

--- a/articat/cli.py
+++ b/articat/cli.py
@@ -82,7 +82,7 @@ class CLI:
             dev=dev,
         ):
             if format == "json":
-                print(e.json(exclude=json_exclude), flush=True)  # type: ignore[arg-type]
+                print(e.json(exclude=json_exclude), flush=True)
             else:
                 assert format == "csv"
                 csv_result.append(e.dict(exclude={"metadata": ...}))

--- a/articat/utils/utils.py
+++ b/articat/utils/utils.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import fsspec
 from fsspec import AbstractFileSystem
 
-from articat.artifact import Artifact
+from articat.artifact import Artifact, not_supplied
 from articat.fs_artifact import FSArtifact
 from articat.utils.typing import PathType
 
@@ -149,7 +149,13 @@ def dummy_unsafe_cache(artifact: FSArtifact, cache_dir: PathType | None = None) 
     )
     assert artifact.created is not None
     m.update(artifact.created.strftime(Artifact._partition_str_format).encode("UTF-8"))
-    m.update((artifact.version and artifact.version.encode("UTF-8")) or b"")
+    m.update(
+        (
+            artifact.version not in {None, not_supplied}
+            and artifact.version.encode("UTF-8")  # type: ignore[union-attr]
+        )
+        or b""
+    )
     hex = m.hexdigest()
 
     cache_entry = cache_dir_path.joinpath(hex)


### PR DESCRIPTION
Handle `None` as explicit `version` value in the lookup ops.