### PR TITLE
Upgrade Pydantic to 2.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,4 +26,4 @@ repos:
         args: ["--strict", "--show-error-codes", "--pretty", "--show-error-context"]
         additional_dependencies:
         - pandas==1.5.2
-        - pydantic==1.10.4
+        - pydantic==2.0.2

--- a/articat/catalog.py
+++ b/articat/catalog.py
@@ -228,7 +228,7 @@ class Catalog(ConfigMixin):
         """
         assert issubclass(model, Artifact)
         yield from (
-            model.parse_obj(r)
+            model.model_validate(r)
             for r in cls._lookup(
                 id=id,
                 partition_dt_start=partition_dt_start,
@@ -290,7 +290,7 @@ class Catalog(ConfigMixin):
 
         exclude = None if include_arbitrary else {"metadata": {"arbitrary": ...}}
         catalog_dicts = [
-            i.dict(exclude=exclude)
+            i.model_dump(exclude=exclude)
             for i in cls.lookup(dev=dev, limit=limit, model=Artifact)
         ]
         return pd.json_normalize(catalog_dicts, sep="_")

--- a/articat/catalog_datastore.py
+++ b/articat/catalog_datastore.py
@@ -118,7 +118,7 @@ class CatalogDatastore(Catalog):
     @classmethod
     def _put_entity(cls, key: Key, artifact: Artifact, client: Client) -> None:
         catalog_entity = datastore.Entity(key)
-        record = artifact.dict(exclude=artifact._exclude_private_fields())
+        record = artifact.model_dump(exclude=artifact._exclude_private_fields())
 
         if artifact.metadata is not None:
             # This fields are not indexed, and therefor can't be match on

--- a/articat/catalog_local.py
+++ b/articat/catalog_local.py
@@ -93,7 +93,7 @@ class CatalogLocal(Catalog):
                     raise ValueError(
                         f"Catalog already contains artifact: {artifact.spec()!r}"
                     )
-            db[db_key] = artifact.json()
+            db[db_key] = artifact.model_dump_json()
         return artifact
 
     @classmethod

--- a/articat/cli.py
+++ b/articat/cli.py
@@ -36,9 +36,9 @@ class CLI:
             artifact = Artifact.partitioned(id=id, partition=partition)  # type: ignore[arg-type]
         artifact = artifact.fetch()
         if hasattr(artifact, "files_pattern"):
-            artifact = FSArtifact.parse_obj(artifact)
+            artifact = FSArtifact.model_validate(artifact)
         elif hasattr(artifact, "table_id"):
-            artifact = BQArtifact.parse_obj(artifact)
+            artifact = BQArtifact.model_validate(artifact)
         else:
             raise ValueError(f"Don't know how to open {artifact}")
         logger.info(f"Opening artifact: {artifact.spec()} via {artifact.browser_url()}")
@@ -86,10 +86,10 @@ class CLI:
             dev=dev,
         ):
             if format == "json":
-                print(e.json(exclude=json_exclude), flush=True)
+                print(e.model_dump_json(exclude=json_exclude), flush=True)
             else:
                 assert format == "csv"
-                csv_result.append(e.dict(exclude={"metadata": ...}))
+                csv_result.append(e.model_dump(exclude={"metadata": ...}))
         if len(csv_result) > 0:
             import pandas as pd
 

--- a/articat/fs_artifact.py
+++ b/articat/fs_artifact.py
@@ -183,7 +183,7 @@ class FSArtifact(Artifact):
                 "Manifest file `_MANIFEST.json` already present in the staged files - this is not supported"
             )
         with fs.open(f"{actual_prefix}/_MANIFEST.json", "w") as m:
-            m.write(self.json(exclude=self._exclude_private_fields()))
+            m.write(self.model_dump_json(exclude=self._exclude_private_fields()))
         try:
             # truncate false, means if the file already exists do not
             # truncate it, which is what we want. If the file

--- a/articat/tests/utils_test.py
+++ b/articat/tests/utils_test.py
@@ -138,7 +138,7 @@ def test_cache__env_var(monkeypatch: MonkeyPatch, caching_artifact: FSArtifact) 
 def test_cache__diff_artifact_id(caching_artifact: FSArtifact) -> None:
     cache_dir = Path(tempfile.mkdtemp())
     b = dummy_unsafe_cache(caching_artifact, cache_dir)
-    diff_art = caching_artifact.copy(update={"id": "sth_diff"})
+    diff_art = caching_artifact.model_copy(update={"id": "sth_diff"})
     c = dummy_unsafe_cache(diff_art, cache_dir)
     assert cache_dir.as_posix() in b
     assert cache_dir.as_posix() in c
@@ -151,9 +151,11 @@ def test_cache__diff_artifact_partition_version_created(
     monkeypatch.setattr(Artifact, "_partition_str_format", "%Y%m%dT%H%M%S%f")
     cache_dir = Path(tempfile.mkdtemp())
     b = dummy_unsafe_cache(caching_artifact, cache_dir)
-    diff_partition = caching_artifact.copy(update={"partition": datetime.utcnow()})
-    diff_version = caching_artifact.copy(update={"version": "0.1.3"})
-    diff_created = caching_artifact.copy(update={"created": datetime.utcnow()})
+    diff_partition = caching_artifact.model_copy(
+        update={"partition": datetime.utcnow()}
+    )
+    diff_version = caching_artifact.model_copy(update={"version": "0.1.3"})
+    diff_created = caching_artifact.model_copy(update={"created": datetime.utcnow()})
     c = dummy_unsafe_cache(diff_partition, cache_dir)
     d = dummy_unsafe_cache(diff_version, cache_dir)
     e = dummy_unsafe_cache(diff_created, cache_dir)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ google-cloud-bigquery >= 1.11
 google-cloud-datastore >= 2.1
 jupyterlab ~= 3.0
 papermill >= 2.0
-pydantic ~= 1.8
+pydantic ~= 2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     google-cloud-bigquery >= 1.11
     google-cloud-datastore >= 2.1
     papermill >= 2.3
-    pydantic ~= 1.8
+    pydantic ~= 2.0
 
 [flake8]
 ignore =


### PR DESCRIPTION
This PR upgrades the pydantic requirement to 2.0 without retaining compatibility for pydantic 1.0. While supporting both pydantic versions is possible, it is challenging to implement and probably not worth it for a package without a large userbase.

articat API changes to reflect [renamed](https://docs.pydantic.dev/dev-v2/migration/#migration-guide) BaseModel methods.

We won't want to merge this until downstream packages using `articat` are ready for pydantic 2.0.