### PR TITLE
google.cloud.datastore add_filter warnings

### DIFF
--- a/articat/catalog_datastore.py
+++ b/articat/catalog_datastore.py
@@ -112,7 +112,7 @@ class CatalogDatastore(Catalog):
                 query.order = ["-partition"]
         if version is not not_supplied:
             # NOTE: version may be None here, and that's fine
-            query.add_filter("version", "=", version)
+            query.add_filter(filter=PropertyFilter("version", "=", version))
         if metadata is not None:
             if metadata.schema_fields:
                 for f in metadata.schema_fields:

--- a/articat/catalog_datastore.py
+++ b/articat/catalog_datastore.py
@@ -7,6 +7,7 @@ from typing import Any, TypeVar
 
 from google.cloud import datastore
 from google.cloud.datastore import Client, Entity, Key
+from google.cloud.datastore.query import PropertyFilter
 
 from articat.artifact import ID, Artifact, Metadata, Partition, Version, not_supplied
 from articat.catalog import Catalog
@@ -91,16 +92,22 @@ class CatalogDatastore(Catalog):
                 and partition_dt_start == partition_dt_end
             ):
                 query.add_filter(
-                    "partition", "=", convert_to_datetime(partition_dt_start)
+                    filter=PropertyFilter(
+                        "partition", "=", convert_to_datetime(partition_dt_start)
+                    )
                 )
             else:
                 if partition_dt_start is not None:
                     query.add_filter(
-                        "partition", ">=", convert_to_datetime(partition_dt_start)
+                        filter=PropertyFilter(
+                            "partition", ">=", convert_to_datetime(partition_dt_start)
+                        )
                     )
                 if partition_dt_end is not None:
                     query.add_filter(
-                        "partition", "<", convert_to_datetime(partition_dt_end)
+                        filter=PropertyFilter(
+                            "partition", "<", convert_to_datetime(partition_dt_end)
+                        )
                     )
                 query.order = ["-partition"]
         if version is not not_supplied:
@@ -109,10 +116,14 @@ class CatalogDatastore(Catalog):
         if metadata is not None:
             if metadata.schema_fields:
                 for f in metadata.schema_fields:
-                    query.add_filter("metadata.schema_fields", "=", f)
+                    query.add_filter(
+                        filter=PropertyFilter("metadata.schema_fields", "=", f)
+                    )
             if metadata.arbitrary is not None:
                 for k, v in metadata.arbitrary.items():
-                    query.add_filter(f"metadata.arbitrary.{k}", "=", v)
+                    query.add_filter(
+                        filter=PropertyFilter(f"metadata.arbitrary.{k}", "=", v)
+                    )
         yield from query.fetch(limit)
 
     @classmethod


### PR DESCRIPTION
refs https://github.com/googleapis/python-datastore/issues/504

To get rid of:

```
UserWarning: Detected filter using positional arguments. Prefer using the 'filter' keyword argument instead.
```

Untested locally, so do not merge unless CI passes and CI uses one of these filters.