### PR TITLE
Set maximum version for fsspec because it is super unstable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fire >= 0.4
+# See https://github.com/related-sciences/articat/pull/59
 fsspec >= 2021.7.0, < 2024.3.0
 gcsfs >= 2021.7.0
 google-cloud-bigquery >= 1.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 fire >= 0.4
-fsspec >= 2021.7.0
+fsspec >= 2021.7.0, < 2024.3.0
 gcsfs >= 2021.7.0
 google-cloud-bigquery >= 1.11
 google-cloud-datastore >= 2.1


### PR DESCRIPTION
* When working on https://github.com/related-sciences/articat/pull/57, I had to fix some behavior changes that crept in via an fsspec upgrade. In order to catch these issues in the future, I also set up a weekly test to catch any more regressions like that, which are easily possible since we don't pin dependencies in this library. Well, it's been two whole weeks, and fsspec released an updated version that somehow changed behavior again and showed up in the [weekly test](https://github.com/related-sciences/articat/actions/runs/8424782759/job/23069461926).
* I didn't really want to spend time chasing down what exactly changed, but I can see by toggling versions and running tests that something did. This is a silly problem to chase, so I put a version restriction that effectively keeps `articat` on `fsspec==2024.2.0`, which is what `facets` uses.