### PR TITLE
Implement custom exceptions for specific error situations

### DIFF
--- a/articat/catalog.py
+++ b/articat/catalog.py
@@ -12,6 +12,10 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=Artifact)
 
+# Custom exception for missing artifacts
+class MissingArtifactException(ValueError):
+    """Exception raised when an artifact cannot be found."""
+    pass
 
 class Catalog(ConfigMixin):
     """RS Data Catalog"""
@@ -114,7 +118,7 @@ class Catalog(ConfigMixin):
             )
         except StopIteration as e:
             req = {"id": id, "partition": partition, "version": version, "dev": dev}
-            raise ValueError(f"Can't find requested artifact {req}") from e
+            raise MissingArtifactException(f"Can't find requested artifact {req}") from e
 
     @classmethod
     @overload
@@ -142,7 +146,7 @@ class Catalog(ConfigMixin):
                 )
             )
         except StopIteration as e:
-            raise ValueError(f"Can't find requested artifact {id}") from e
+            raise MissingArtifactException(f"Can't find requested artifact {id}") from e
 
     @classmethod
     @overload

--- a/articat/catalog.py
+++ b/articat/catalog.py
@@ -7,15 +7,12 @@ from typing import Any, TypeVar, overload
 
 from articat.artifact import ID, Artifact, Metadata, Partition, Version, not_supplied
 from articat.config import ArticatConfig, ConfigMixin
+from articat.exceptions import MissingArtifactException
 
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=Artifact)
 
-# Custom exception for missing artifacts
-class MissingArtifactException(ValueError):
-    """Exception raised when an artifact cannot be found."""
-    pass
 
 class Catalog(ConfigMixin):
     """RS Data Catalog"""
@@ -118,7 +115,9 @@ class Catalog(ConfigMixin):
             )
         except StopIteration as e:
             req = {"id": id, "partition": partition, "version": version, "dev": dev}
-            raise MissingArtifactException(f"Can't find requested artifact {req}") from e
+            raise MissingArtifactException(
+                f"Can't find requested artifact {req}"
+            ) from e
 
     @classmethod
     @overload

--- a/articat/exceptions.py
+++ b/articat/exceptions.py
@@ -1,0 +1,4 @@
+class MissingArtifactException(ValueError):
+    """Exception raised when an artifact cannot be found."""
+
+    pass

--- a/articat/tests/catalog_datastore_test.py
+++ b/articat/tests/catalog_datastore_test.py
@@ -13,6 +13,7 @@ from articat.tests.utils import (
     TestFSArtifact,
     write_a_couple_of_partitions,
 )
+from articat.catalog import MissingArtifactException
 
 # Tests in this module require Datastore emulator, and by default won't run
 # unless pytest has been told that the emulator is in fact available
@@ -234,12 +235,12 @@ def test_catalog_latest_partition(uid: ID) -> None:
 
 
 def test_catalog_get_nice_error_on_missing_get(uid: ID) -> None:
-    with pytest.raises(ValueError, match="Can't find requested artifact"):
+    with pytest.raises(MissingArtifactException, match="Can't find requested artifact"):
         TestCatalog.get(uid, version="0.1.1")
 
 
 def test_catalog_get_nice_error_on_missing_latest(uid: ID) -> None:
-    with pytest.raises(ValueError, match="Can't find requested artifact"):
+    with pytest.raises(MissingArtifactException, match="Can't find requested artifact"):
         TestCatalog.latest_partition(uid)
 
 

--- a/articat/tests/catalog_datastore_test.py
+++ b/articat/tests/catalog_datastore_test.py
@@ -7,13 +7,13 @@ from _pytest.monkeypatch import MonkeyPatch
 from dateutil.tz import UTC
 
 from articat.artifact import EXECUTION_URL_ENV_NAME, ID, Metadata
+from articat.exceptions import MissingArtifactException
 from articat.fs_artifact import FSArtifact
 from articat.tests.utils import (
     TestCatalog,
     TestFSArtifact,
     write_a_couple_of_partitions,
 )
-from articat.catalog import MissingArtifactException
 
 # Tests in this module require Datastore emulator, and by default won't run
 # unless pytest has been told that the emulator is in fact available

--- a/articat/tests/catalog_local_test.py
+++ b/articat/tests/catalog_local_test.py
@@ -1,8 +1,10 @@
 import pytest
 
 from articat.catalog_local import CatalogLocal
-from articat.tests.utils import TestFSArtifact
-from articat.catalog import MissingArtifactException  # Ensure MissingArtifactException is imported
+from articat.exceptions import (
+    MissingArtifactException,  # Ensure MissingArtifactException is imported
+)
+
 
 def test_catalog_local_missing_artifact_exception():
     """

--- a/articat/tests/catalog_local_test.py
+++ b/articat/tests/catalog_local_test.py
@@ -1,9 +1,7 @@
 import pytest
 
 from articat.catalog_local import CatalogLocal
-from articat.exceptions import (
-    MissingArtifactException,  # Ensure MissingArtifactException is imported
-)
+from articat.exceptions import MissingArtifactException
 
 
 def test_catalog_local_missing_artifact_exception():
@@ -11,6 +9,5 @@ def test_catalog_local_missing_artifact_exception():
     Test that `MissingArtifactException` is raised when an artifact cannot be found in `CatalogLocal`.
     """
     catalog = CatalogLocal()
-    with pytest.raises(MissingArtifactException) as exc_info:
+    with pytest.raises(MissingArtifactException, match="Can't find requested artifact"):
         catalog.get("non_existing_artifact_id")
-    assert "Can't find requested artifact" in str(exc_info.value)

--- a/articat/tests/catalog_local_test.py
+++ b/articat/tests/catalog_local_test.py
@@ -1,0 +1,14 @@
+import pytest
+
+from articat.catalog_local import CatalogLocal
+from articat.tests.utils import TestFSArtifact
+from articat.catalog import MissingArtifactException  # Ensure MissingArtifactException is imported
+
+def test_catalog_local_missing_artifact_exception():
+    """
+    Test that `MissingArtifactException` is raised when an artifact cannot be found in `CatalogLocal`.
+    """
+    catalog = CatalogLocal()
+    with pytest.raises(MissingArtifactException) as exc_info:
+        catalog.get("non_existing_artifact_id")
+    assert "Can't find requested artifact" in str(exc_info.value)

--- a/articat/tests/utils_test.py
+++ b/articat/tests/utils_test.py
@@ -14,7 +14,6 @@ from articat.utils import utils
 from articat.utils.path_utils import cwd
 from articat.utils.typing import PathType
 from articat.utils.utils import download_artifact, dummy_unsafe_cache, get_repo_and_hash
-from articat.catalog import MissingArtifactException
 
 def get_source_path_that_looks_like_path_from_catalog() -> Path:
     p = Path(

--- a/articat/tests/utils_test.py
+++ b/articat/tests/utils_test.py
@@ -14,7 +14,7 @@ from articat.utils import utils
 from articat.utils.path_utils import cwd
 from articat.utils.typing import PathType
 from articat.utils.utils import download_artifact, dummy_unsafe_cache, get_repo_and_hash
-
+from articat.catalog import MissingArtifactException
 
 def get_source_path_that_looks_like_path_from_catalog() -> Path:
     p = Path(


### PR DESCRIPTION
Related to #52

Introduces custom exception handling for missing artifacts in the Articat project.

- Implements a new custom exception class `MissingArtifactException` inheriting from `ValueError` to provide more specific error handling when an artifact cannot be found.
- Replaces `ValueError` with `MissingArtifactException` in `articat/catalog.py` for both `get` and `latest_partition` methods to improve error specificity.
- Adds a new test file `articat/tests/catalog_local_test.py` with a test case ensuring `MissingArtifactException` is raised appropriately when an artifact cannot be found in `CatalogLocal`.
- Updates existing tests in `articat/tests/utils_test.py` and `articat/tests/catalog_datastore_test.py` to expect `MissingArtifactException` instead of `ValueError` for missing artifacts, aligning test expectations with the new exception handling.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/related-sciences/articat/issues/52?shareId=4b2dba69-8641-49e6-aadb-754472460eb9).

---

_Note - this was implemented entirely by letting Copilot Workspace do its thing, with me doing a bit of editing / removing extraneous changes). This was meant to be a test of the product, but we may well wish to use the resulting changes_