### PR TITLE
Pin numpy requirement to <2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 codecov
 pandas==1.5.2
+numpy>=1.21.0, <2.0.0
 pre-commit
 pytest
 pytest-cov


### PR DESCRIPTION
Fixes binary incompatibility seen in https://github.com/related-sciences/articat/actions/runs/9768343310/job/26965613878, due to environment picking up the newly-released numpy 2.0

Passing CI in https://github.com/related-sciences/articat/actions/runs/9768690168/job/26966722443

The minimum version here is what was required by the specified version of pandas

