### PR TITLE
Support pydantic 2.0 via backport module

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,5 +24,5 @@ repos:
         args:
           ["--strict", "--show-error-codes", "--pretty", "--show-error-context"]
         additional_dependencies:
-          - pandas==1.5.2
-          - pydantic==1.10.4
+        - pandas==2.2.1
+        - pydantic>=2.0.0

--- a/articat/artifact.py
+++ b/articat/artifact.py
@@ -10,7 +10,7 @@ from typing import Any, ClassVar, TypeVar
 
 from google.cloud import datastore
 from google.cloud.datastore.helpers import entity_to_protobuf
-from pydantic import BaseModel, Extra, validator
+from pydantic.v1 import BaseModel, Extra, validator
 
 from articat.config import ArticatConfig, ArticatMode, ConfigMixin
 from articat.utils.datetime_utils import convert_to_datetime

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 codecov
-pandas==1.5.2
+pandas==2.2.1
 numpy>=1.21.0, <2.0.0
 pre-commit
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ google-cloud-bigquery >= 1.11
 google-cloud-datastore >= 2.1
 jupyterlab ~= 3.0
 papermill >= 2.0
-pydantic ~= 1.8
+pydantic ~= 2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     google-cloud-bigquery >= 1.11
     google-cloud-datastore >= 2.1
     papermill >= 2.3
-    pydantic ~= 1.8
+    pydantic ~= 2.0
 
 [flake8]
 ignore =


### PR DESCRIPTION
* To support using provider-agnostic llm libraries in facets, we'll want to be able to run all dependencies with pydantic 2.x. This repository was a blocker.
* I made note of the changes in https://github.com/related-sciences/articat/pull/51/, and attempted to re-run tests from that revision, but encountered some puzzling errors around private attributes and our ConfigMixin (visible [here](https://github.com/related-sciences/articat/actions/runs/13338974769/job/37260101087#step:8:2448))
* In the spirit of moving forward incrementally, I thought it would better serve our purposes to use the backported v1 api, as detailed [here](https://docs.pydantic.dev/latest/migration/#using-pydantic-v1-features-in-a-v1v2-environment). Our only aim at this stage is to allow using pydantic 2.x, not use any of its features in the articat library, so I thought that this would best unblock us
* In facets, we'll be able to choose whether to use backports or new features on a case-by-case basis.
* Passing tests in https://github.com/related-sciences/articat/actions/runs/13338815948/job/37259635879

cc @ravwojdyla @dhimmel 